### PR TITLE
Add :focus-visible pseudoclass

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -1621,7 +1621,7 @@
     'match': '''(?xi)
       (:)(:*)
       (?: active|any-link|checked|default|disabled|empty|enabled|first
-        | (?:first|last|only)-(?:child|of-type)|focus|focus-within|fullscreen|host|hover
+        | (?:first|last|only)-(?:child|of-type)|focus|focus-visible|focus-within|fullscreen|host|hover
         | in-range|indeterminate|invalid|left|link|optional|out-of-range
         | read-only|read-write|required|right|root|scope|target|unresolved
         | valid|visited


### PR DESCRIPTION
### Description of the Change

Enable syntax hilighting for the `:focus-visible` CSS pseudo-class

### Benefits

Support this relatively used pseudo-class (Compatible with latest Chrome, Firefox, Edge, Opera as of writing)

Ref. https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible

### Possible Drawbacks

I can't think of one ;-) 